### PR TITLE
changed default encoding from ASCII to CP1250

### DIFF
--- a/librouteros/connections.py
+++ b/librouteros/connections.py
@@ -34,7 +34,7 @@ class Encoder:
         :param word: Word to encode.
         :returns: Encoded word.
         '''
-        encoded_word = word.encode(encoding='ASCII', errors='strict')
+        encoded_word = word.encode(encoding='cp1250', errors='strict')
         return Encoder.encodeLength(len(word)) + encoded_word
 
     @staticmethod
@@ -131,7 +131,7 @@ class Decoder:
             word_length = Decoder.decodeLength(sentence[start:end])
             words.append(sentence[end:word_length+end])
             start, end = end + word_length, end + word_length + 1
-        return tuple(word.decode(encoding='ASCII', errors='strict') for word in words)
+        return tuple(word.decode(encoding='cp1250', errors='strict') for word in words)
 
 
 class ApiProtocol(Encoder, Decoder):


### PR DESCRIPTION
Decode fails when comments contain non-ASCII characters (Polish diactrics, for example). After changing the decode encoding to CP1250 the problem disappears. I'm using the API only to read, but I've also changed the encode encoding to CP1250 for the sake of consistency.