### PR TITLE
Drop support for EOL Python 3.2 and 3.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ MANIFEST
 
 #pytest cache
 .cache
+
+# PyCharm IDE
+.idea

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ language: python
 cache: pip
 python:
   - 2.7
-  - 3.2
   - 3.3
   - 3.4
   - 3.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ language: python
 cache: pip
 python:
   - 2.7
-  - 3.3
   - 3.4
   - 3.5
   - 3.6

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',

--- a/setup.py
+++ b/setup.py
@@ -3,9 +3,7 @@
 from setuptools import setup
 from sys import version_info
 
-pyversion = version_info.major, version_info.minor
-
-if pyversion > (3, 2):
+if version_info.major >= 3:
     install_pkgs = ()
 else:
     install_pkgs = (
@@ -54,11 +52,14 @@ setup(
         'Operating System :: Microsoft :: Windows',
         'Operating System :: POSIX',
         'Operating System :: Unix',
+        'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.2',
+        'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: Implementation :: CPython',
         'Topic :: Software Development :: Libraries'
         ]
      )

--- a/tests/requirements/test_requirements.py
+++ b/tests/requirements/test_requirements.py
@@ -2,16 +2,14 @@ import pip
 import pytest
 from sys import version_info
 
-pyversion = version_info.major, version_info.minor
 
-
-@pytest.mark.skipif(pyversion > (3, 2), reason='collections.ChainMap is in >= 3.3')
+@pytest.mark.skipif(version_info.major >= 3, reason='collections.ChainMap is in >= 3.3')
 def test_chainmap_installed():
     pkgs = pip.utils.get_installed_distributions(local_only=True, include_editables=False)
     assert 'chainmap' in (pkg.key for pkg in pkgs)
 
 
-@pytest.mark.skipif(pyversion < (3, 3), reason='ChainMap installed from pip')
+@pytest.mark.skipif(version_info.major < 3, reason='ChainMap installed from pip')
 def test_chainmap_not_installed():
     pkgs = pip.utils.get_installed_distributions(local_only=True, include_editables=False)
     assert 'chainmap' not in (pkg.key for pkg in pkgs)


### PR DESCRIPTION
Fixes https://github.com/luqasz/librouteros/issues/15.

Also drops support for EOL Python 3.3, which is barely used.

Here's the pip installs for librouteros from PyPI for the last year:
```
$ pypinfo -d 365 --percent --pip librouteros pyversion
python_version percent download_count
-------------- ------- --------------
2.7              48.5%          7,066
3.6              19.8%          2,882
3.5              18.3%          2,661
3.4              13.1%          1,913
2.6               0.3%             50
3.3               0.0%              1
```

Also takes the opportunity to clean up some bits and pieces.

