### PR TITLE
Fix returns with characters latin-1

### DIFF
--- a/librouteros/__init__.py
+++ b/librouteros/__init__.py
@@ -18,7 +18,7 @@ defaults = {
             'port': 8728,
             'saddr': '',
             'subclass': Api,
-            'encoding': 'ASCII',
+            'encoding': 'latin-1',
             'ssl_wrapper': lambda sock: sock,
             }
 


### PR DESCRIPTION
I change default json ASCII to latin-1, and now accept ç and anothers characters

'latin-1' work to language portuguese ( pt-PT and pt-BR )