### PR TITLE
Fixed crash on socket recv

### DIFF
--- a/librouteros/connections.py
+++ b/librouteros/connections.py
@@ -22,7 +22,13 @@ class SocketTransport:
         """
         data = bytearray()
         while len(data) != length:
-            data += self.sock.recv((length - len(data)))
+            tmp = None
+            try:
+                tmp = self.sock.recv((length - len(data)))
+            except:
+                raise ConnectionClosed('Socket recv failed.')
+
+            data += tmp
             if not data:
                 raise ConnectionClosed('Connection unexpectedly closed.')
         return data


### PR DESCRIPTION
Here is a fix I made for frequent crashes during socket recv.
From observations, it happens more frequently on slower devices, like rb450

I have been using this fix in my project [tomaae/homeassistant-mikrotik_router](https://github.com/tomaae/homeassistant-mikrotik_router) for some time and it works well.