### PR TITLE
Fixed the encode when latin characters are used inside comments.

### DIFF
--- a/librouteros/protocol.py
+++ b/librouteros/protocol.py
@@ -202,7 +202,7 @@ class ApiProtocol(Encoder, Decoder):
         byte += self.transport.read(to_read)
         length = self.decodeLength(byte)
         word = self.transport.read(length)
-        return word.decode(encoding=self.encoding, errors='strict')
+        return word.decode(encoding='windows-1250', errors='strict')
 
     def close(self) -> None:
         self.transport.close()


### PR DESCRIPTION
When a latin characters is used in a comment (DHCP client, for example), a exception is throwed, because the base encoding is `utf-8`. The data sent by API is encoded in `windows-1250`.