### PR TITLE
Fix encoding of words for encodings with > 1 bytes per character

### DIFF
--- a/librouteros/protocol.py
+++ b/librouteros/protocol.py
@@ -72,7 +72,7 @@ class Encoder:
         """
         #pylint: disable=no-member
         encoded_word = word.encode(encoding=self.encoding, errors='strict') # type: ignore
-        return Encoder.encodeLength(len(word)) + encoded_word
+        return Encoder.encodeLength(len(encoded_word)) + encoded_word
 
     @staticmethod
     def encodeLength(length: int) -> bytes:


### PR DESCRIPTION
If `word` happens to be `"ö"` and `encoding == 'utf-8'`, `len(word) == 1`, while `len(encoded_word) == 2`. This leads to strange errors like timeouts or connection unexpectedly closed errors.

With this change I was able to set a comment to an UTF-8 encoded `ö` successfully (as a simple test) :-) (Unfortunately Webfig butchers it by decoding the UTF-8 as Latin1, but that's another unrelated issue... SSH correct recovers that value correctly as `comment="\C3\B6"`)