### PR TITLE
Fix import of excaptions in apicli

### DIFF
--- a/apicli.py
+++ b/apicli.py
@@ -11,7 +11,8 @@ from sys import stdout, stdin
 from select import select
 from os import linesep
 
-from librouteros import connect, ConnectionError, TrapError, FatalError
+from librouteros import connect
+from librouteros.exceptions import TrapError, FatalError
 
 argParser = ArgumentParser(description='mikrotik api cli interface')
 argParser.add_argument(


### PR DESCRIPTION
- Some exceptions could not be imported so changing the import to ``librouteros.exceptions```.
- The ```ConnectionError``` is a build-in exception from Python