### PR TITLE
Fix doc formatting

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 # If your documentation needs a minimal Sphinx version, state it here.

--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -20,6 +20,6 @@ Limitations
 Requirements
 ------------
 
-* Python 3, with sufficiently recent versions of `pip` and `setuptools`
+* Python 3, with sufficiently recent versions of ``pip`` and ``setuptools``
 * Mock (for runing unit tests).
-* `qemu` for running integration tests.
+* ``qemu`` for running integration tests.

--- a/docs/query.rst
+++ b/docs/query.rst
@@ -34,8 +34,8 @@ Syntax is very simmilar to a SQL query.
 
 Above code demonstrates how to select ``name``, ``disabled`` fields where each interface is disabled
 and ``name`` is equal to one of ``ether2``, ``wlan-lan``.
-If you do not specify any logical operation within `where()`, them it defaults to `And()`.
-Above example can be rewritten using `In` operator.
+If you do not specify any logical operation within ``where()``, them it defaults to `And()`.
+Above example can be rewritten using ``In`` operator.
 
 .. code-block:: python
 


### PR DESCRIPTION
- The shebang from conf.py has been removed from the sphinx template and isn't used anyway.
- Code has to have two backticks