### PR TITLE
Adding support for proxy_command

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -102,6 +102,15 @@ jobs:
           qemu-system-i386
           qemu-utils
 
+      - name: set-up ssh
+        run: |
+          sudo apt-get install -y openssh-server
+          sudo systemctl enable ssh
+          sudo systemctl start ssh
+          mkdir -p $HOME/.ssh
+          ssh-keygen -t ed25519 -N "" -f $HOME/.ssh/id_ed25519
+          cp -av $HOME/.ssh/id_ed25519.pub $HOME/.ssh/authorized_keys
+
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}

--- a/tests/integration/test_proxy.py
+++ b/tests/integration/test_proxy.py
@@ -1,0 +1,59 @@
+import pytest
+
+
+def test_proxy_netcat(routeros_api_sync_netcat):
+    api = routeros_api_sync_netcat
+    identity = api.path("system", "identity")
+    idents = []
+    for item in identity:
+        idents.append(item)
+    assert len(idents[0]["name"]) > 0
+    api.close()
+
+
+def test_proxy_ssh(routeros_api_sync_ssh):
+    api = routeros_api_sync_ssh
+    identity = api.path("system", "identity")
+    idents = []
+    for item in identity:
+        idents.append(item)
+    assert len(idents[0]["name"]) > 0
+    api.close()
+
+
+def test_ssl_netcat(routeros_api_ssl_netcat):
+    api = routeros_api_ssl_netcat
+    identity = api.path("system", "identity")
+    idents = []
+    for item in identity:
+        idents.append(item)
+    assert len(idents[0]["name"]) > 0
+    api.close()
+
+
+def test_ssl_ssh(routeros_api_ssl_ssh):
+    api = routeros_api_ssl_ssh
+    identity = api.path("system", "identity")
+    idents = []
+    for item in identity:
+        idents.append(item)
+    assert len(idents[0]["name"]) > 0
+    api.close()
+
+
+@pytest.mark.asyncio
+async def test_proxy_netcat_async(routeros_api_async_netcat):
+    identity = routeros_api_async_netcat.path("system", "identity")
+    idents = []
+    async for item in identity:
+        idents.append(item)
+    assert len(idents[0]["name"]) > 0
+
+
+@pytest.mark.asyncio
+async def test_proxy_ssh_async(routeros_api_async_ssh):
+    identity = routeros_api_async_ssh.path("system", "identity")
+    idents = []
+    async for item in identity:
+        idents.append(item)
+    assert len(idents[0]["name"]) > 0

--- a/tests/unit/test_librouteros.py
+++ b/tests/unit/test_librouteros.py
@@ -36,6 +36,7 @@ from librouteros.login import (
         ("encoding", "ASCII"),
         ("login_method", plain),
         ("ssl_wrapper", None),
+        ("proxy_command", None),
     ),
 )
 def test_defaults(key, value):
@@ -52,6 +53,7 @@ def test_defaults(key, value):
         ("encoding", "ASCII"),
         ("login_method", async_plain),
         ("ssl_wrapper", None),
+        ("proxy_command", None),
     ),
 )
 def test_async_defaults(key, value):
@@ -180,3 +182,26 @@ async def test_async_create_connection_does_not_wrap_socket_exceptions(create_co
     transport.side_effect = exc
     with pytest.raises(exc):
         await create_transport(**kwargs)
+
+
+@patch("librouteros.proxy_connect")
+def test_create_transport_handles_proxy_command(conn_mock):
+    params = DEFAULTS.copy()
+    params["proxy_command"] = "sleep 60"
+    conn_mock.return_value = (Mock(), Mock())
+    create_transport(host="127.0.0.1", **params)
+    assert conn_mock.call_args == call(
+        ("127.0.0.1", params["port"]),
+        params["proxy_command"],
+    )
+
+
+@pytest.mark.asyncio
+@patch("librouteros.asyncio.open_connection")
+async def test_async_create_transport_handles_proxy_command(conn_mock):
+    params = ASYNC_DEFAULTS.copy()
+    params["proxy_command"] = "sleep 60"
+    conn_mock.return_value = (Mock(), Mock())
+    await async_create_transport(host="127.0.0.1", **params)
+    _, kwargs = conn_mock.call_args
+    assert isinstance(kwargs["sock"], socket.socket)


### PR DESCRIPTION
This implements `proxy_command` functionality in the same vein as OpenSSH's
ProxyCommand option.  (See [example](https://www.cyberciti.biz/faq/linux-unix-ssh-proxycommand-passing-through-one-host-gateway-server/)).

It adds a new kwargs to the `connect` and the `async_connect` functions:

- `proxy_command` : Connect to host using the given proxy command.  (If not specified
   a direct connection is used.

Example `proxy_command`:

```
ssh -o StrictHostKeyChecking=accept-new -W %h:%p bastion
```

This allows `librouteros` to connect devices that are not directly connected to us.  This
is a very common scenario where network devices are on a special secure network,
and/or can only be accessed from dedicated security devices.  I personally use it for testing
where the test devices are in a virtual network, the proxy command allows `librouteros`
to tunnel the connection over a virtual interface.

There are two implementations, one uses low-level OS calls, and a generic one based on `subprocess.Popen`.  The later is more portable and should run on Windows, but
I have not tested that.

