### PR TITLE
Preserve leading-zero identifiers in parse_word

### DIFF
--- a/src/librouteros/protocol.py
+++ b/src/librouteros/protocol.py
@@ -32,7 +32,9 @@ def parse_word(word: str) -> tuple[str, ROSType]:
     mapping: dict[str, bool] = {"yes": True, "true": True, "no": False, "false": False}
     _, key, value = word.split("=", 2)
     try:
-        ros_value: ROSType = int(value)
+        as_int = int(value)
+        # Keep int only if str cast gives original value, else preserve string ("00" -> "00").
+        ros_value: ROSType = as_int if str(as_int) == value else value
     except ValueError:
         ros_value = mapping.get(value, value)
     return (key, ros_value)

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -38,6 +38,20 @@ def test_parse_word(word_pair):
     assert parse_word(word_pair.word) == word_pair.pair
 
 
+@pytest.mark.parametrize(
+    ("word", "pair"),
+    (
+        ("=name=00", ("name", "00")),
+        ("=name=000", ("name", "000")),
+        ("=name=0000", ("name", "0000")),
+        ("=name=007", ("name", "007")),
+    ),
+)
+def test_parse_word_preserves_leading_zeros(word, pair):
+    """Names like '00', '000', '0000' must stay strings, should not become int 0."""
+    assert parse_word(word) == pair
+
+
 def test_compose_word(word_pair):
     assert compose_word(*word_pair.pair) == word_pair.word
 


### PR DESCRIPTION
Fixes #379 

int("00") casted names like "00"/"000" to int 0.
Keep int only when the str cast of int cast is same, else return the string.

What are your thoughts on this?