### PR TITLE
Add configuration management (Config/AsyncConfig)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,10 @@
+Unreleased
+----------
+
+* Add configuration management (``Config``/``AsyncConfig``, ``api.config()``):
+  export, import/merge, validate, compare, backup, a scheduler-based rollback
+  safety net and reset-based replace. RouterOS 7.x, binary API only (no SSH).
+
 4.1.1
 ----------
 

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -1,0 +1,148 @@
+Configuration management
+========================
+
+The ``Config`` object provides configuration management (export, import/merge,
+compare, backup, replace and a rollback safety net) on top of the binary API. No
+SSH/terminal access is required. It targets **RouterOS 7.x**.
+
+Obtain one from an ``Api`` (or ``AsyncApi``):
+
+.. code-block:: python
+
+    cfg = api.config()
+
+    # async version
+    cfg = async_api.config()
+
+RouterOS configuration is imperative (an ``/export`` is a list of ``add``/``set``
+actions, not declarative state) and has no native, non-reboot commit/rollback.
+This object works within those constraints rather than pretending otherwise; read
+the notes below before using ``replace()`` or the rollback timer in production.
+
+Export
+------
+
+``/export`` returns nothing when run directly over the API, so ``export()``
+writes to a temporary file, reads it back and cleans up. Newlines are normalized
+to ``\n``; the volatile timestamp header line is left intact (use
+``librouteros.compare`` or ``librouteros.config.strip_header`` to normalize it
+away for diffing). Configurations larger than the API's inline limit (a few tens
+of KB) are read back in chunks via ``/file/read`` (RouterOS 7.13+).
+
+.. code-block:: python
+
+    running = cfg.export()
+    running = cfg.export(show_sensitive=True)     # include passwords/keys
+    running = cfg.export(path="ip/address")       # scoped: runs /ip/address/export
+
+    # async version
+    running = await cfg.export()
+
+Apply / merge
+-------------
+
+``apply()`` runs a ``.rsc`` script via ``/import``. Provide exactly one of
+``text`` (uploaded to a temporary file first) or ``filename`` (a file already on
+the device). This is a merge: the script's own ``add``/``set``/``remove`` actions
+are executed in order.
+
+.. code-block:: python
+
+    cfg.apply("/ip address add address=10.0.0.1/24 interface=ether1\n")
+    cfg.apply(filename="deploy.rsc")
+
+    # async version
+    await cfg.apply(text)
+
+Errors are raised as :class:`~librouteros.exceptions.TrapError` (with line and
+column). Import is not transactional: a syntax error aborts before any change is
+made, but a valid-but-failing command applies earlier lines and then stops. Use
+``validate()`` to dry-run a script first (RouterOS 7.16+):
+
+.. code-block:: python
+
+    cfg.validate(text)   # raises TrapError on any error, applies nothing
+
+Compare
+-------
+
+``compare()`` exports the running configuration and returns a human readable
+unified diff against a candidate. It is informational, not an executable RouterOS
+patch. The module level :func:`librouteros.compare` diffs two strings directly.
+
+.. code-block:: python
+
+    print(cfg.compare(candidate))
+
+    from librouteros import compare
+    print(compare(running, candidate))
+
+Backup
+------
+
+.. code-block:: python
+
+    cfg.backup_save("before-change")            # writes before-change.backup
+    cfg.backup_load("before-change")            # restores and REBOOTS the device
+
+Backups are binary, same-device and same-version. Loading one reboots the device
+(the API connection will drop). On devices that keep a RAM disk at the file-system
+root, pass ``persistent=True`` (to both ``backup_save`` and ``backup_load``) to
+store the backup under ``flash/`` so it survives a reboot. By default a backup with
+no password is written unencrypted (it contains secrets); pass a ``password`` to
+encrypt it.
+
+Rollback safety net
+-------------------
+
+RouterOS has no native commit-confirm. ``arm_rollback()`` emulates one with a
+device-side ``/system/scheduler`` job that restores a backup after ``seconds``.
+Because the timer lives on the device it fires even if the client dies, the
+session is lost, or you lock yourself out, with no safe-mode action limit.
+
+.. code-block:: python
+
+    cfg.arm_rollback(120)          # save a backup + schedule a restore in 120s
+    cfg.apply(risky_config)        # push the change
+    if still_reachable():
+        cfg.cancel_rollback()      # confirm: cancel the scheduled restore
+    # otherwise the scheduler fires, restores the backup and reboots
+
+    cfg.rollback_pending()         # True while a rollback is armed
+
+The automatic restore reverts by rebooting, and only within the ``seconds``
+window. That is the trade for a net that survives a lock-out. The backup is stored
+persistently so it survives the reboot. The scheduler job runs with a policy set
+that ``/system backup load`` needs; RouterOS refuses to create the job unless the
+API user holds every listed policy, so a restricted account can pass its own
+``policy=`` to ``arm_rollback``.
+
+Replace
+-------
+
+.. warning::
+
+    ``replace()`` is destructive. It wipes the configuration, reboots and replays
+    the supplied script via ``/system reset-configuration run-after-reset``. There
+    is **no** automatic rollback for a replace: safe mode is ignored for resets,
+    the run-after-reset script must finish within ~2 minutes, and with
+    ``no_defaults`` the script must fully establish management connectivity or the
+    device becomes unreachable. Ensure out-of-band (console / netinstall) recovery
+    is available.
+
+.. code-block:: python
+
+    cfg.replace(full_config)                     # keep_users=True, no_defaults=True
+
+.. note::
+
+    Configuration management requires RouterOS 7.x. Nothing here uses SSH; every
+    operation is a plain API command.
+
+.. note::
+
+    These helpers use fixed device-side file and scheduler names
+    (``librouteros-export``, ``librouteros-import.rsc``, ``librouteros-rollback``,
+    ``librouteros-replace``), so they are not safe to run concurrently against the
+    same device from more than one client. Do not reuse those reserved names in your
+    own configuration.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -32,6 +32,7 @@ Python implementation of `routeros api <http://wiki.mikrotik.com/wiki/API>`_. Th
     connect
     path
     query
+    config
     api_analysis
     license
     contributing

--- a/src/librouteros/__init__.py
+++ b/src/librouteros/__init__.py
@@ -9,6 +9,11 @@ from ssl import SSLContext
 from typing import TypedDict
 
 from librouteros.api import Api, AsyncApi
+from librouteros.config import (
+    AsyncConfig,  # noqa F401
+    Config,  # noqa F401
+    compare,  # noqa F401
+)
 from librouteros.connections import AsyncSocketTransport, SocketTransport
 from librouteros.exceptions import ConnectionClosed, FatalError
 from librouteros.login import (

--- a/src/librouteros/api.py
+++ b/src/librouteros/api.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from collections.abc import Generator
 from posixpath import join as pjoin
 
+from librouteros.config import AsyncConfig, Config
 from librouteros.exceptions import MultiTrapError, TrapError
 from librouteros.protocol import (
     ApiProtocol,
@@ -88,6 +89,10 @@ class Api:
             path="",
             api=self,
         ).join(*path)
+
+    def config(self) -> Config:
+        """Return a configuration management helper bound to this Api."""
+        return Config(api=self)
 
 
 class Path:
@@ -216,6 +221,10 @@ class AsyncApi:
             path="",
             api=self,
         ).join(*path)
+
+    def config(self) -> AsyncConfig:
+        """Return an async configuration management helper bound to this AsyncApi."""
+        return AsyncConfig(api=self)
 
 
 class AsyncPath:

--- a/src/librouteros/config.py
+++ b/src/librouteros/config.py
@@ -1,0 +1,699 @@
+# -*- coding: UTF-8 -*-
+
+"""
+Vendor-generic configuration management built on top of the RouterOS binary API.
+
+Everything here is implemented with plain API commands (``/export``, ``/import``,
+``/file``, ``/system/backup``, ``/system/scheduler``, ``/system/reset-configuration``)
+so no SSH/terminal access is required. RouterOS has no native, non-reboot
+commit/rollback; a device-side ``/system/scheduler`` job that restores a backup acts
+as a dead man's switch (see :meth:`Config.arm_rollback`).
+
+Requires RouterOS 7.x.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import difflib
+import re
+from logging import getLogger
+from posixpath import join as pjoin
+from time import sleep
+from typing import TYPE_CHECKING
+
+from librouteros.exceptions import LibRouterosError, TrapError
+from librouteros.query import And, Key
+from librouteros.types import ReplyDict, ROSType
+
+LOGGER = getLogger("librouteros")
+
+if TYPE_CHECKING:
+    from librouteros.api import Api, AsyncApi
+
+# Transient file / job names used on the device. Reused (and cleaned up) between calls.
+EXPORT_FILE = "librouteros-export"
+IMPORT_FILE = "librouteros-import.rsc"
+ROLLBACK_NAME = "librouteros-rollback"
+REPLACE_NAME = "librouteros-replace"
+
+# Default scheduler policy for the rollback job. This is a known-working set (validated
+# on RouterOS 7.x that the fired job actually loads the backup); a narrower set silently
+# fails at fire time. RouterOS also rejects scheduler creation unless the API user holds
+# every listed policy, so a restricted account can override this via arm_rollback.
+_ROLLBACK_POLICY = "ftp,reboot,read,write,policy,test"
+
+# How much of a large file to pull per /file/read call (bytes).
+_READ_CHUNK = 32768
+# A file just written by /export is briefly unreadable via /file/read even though it
+# already shows up in /file/print; retry the read a few times before giving up.
+_READ_RETRIES = 6
+_READ_RETRY_DELAY = 0.2
+
+# Marks the rollback scheduler as ours so a user job that happens to share the reserved
+# name is not mistaken for it (and never removed by cancel_rollback).
+ROLLBACK_COMMENT = "librouteros rollback dead man switch"
+
+# First line of an /export is a volatile timestamp header:
+#   # 2026-07-11 21:04:13 by RouterOS 7.21.5
+# Strip the date/time so repeated exports diff cleanly.
+_HEADER_RE = re.compile(r"^# \S+ \S+ by (.+)$", flags=re.MULTILINE)
+
+# Query keys for /file and /system/scheduler reads.
+_ID = Key(".id")
+_NAME = Key("name")
+_CONTENTS = Key("contents")
+_TYPE = Key("type")
+_COMMENT = Key("comment")
+_SIZE = Key("size")
+
+
+def strip_header(text: str) -> str:
+    """Replace the volatile ``# <date> <time> by ...`` export header with ``# by ...``."""
+    return _HEADER_RE.sub(r"# by \1", text)
+
+
+def normalize_newlines(text: str) -> str:
+    return text.replace("\r\n", "\n")
+
+
+def normalize_for_diff(text: str) -> list[str]:
+    text = strip_header(normalize_newlines(text))
+    # rstrip each line so trailing-whitespace noise does not show up as a change
+    return [line.rstrip() for line in text.splitlines()]
+
+
+def compare(running: str, candidate: str, *, context: int = 3) -> str:
+    """
+    Return a human readable unified diff between two RouterOS configurations.
+
+    This is informational only, not an executable RouterOS patch. Both sides are
+    normalized (newlines, volatile export header, trailing whitespace) before diffing.
+
+    :param running: Configuration currently on the device (e.g. from :meth:`Config.export`).
+    :param candidate: Desired configuration.
+    :param context: Number of unified-diff context lines.
+    :returns: Unified diff, or an empty string when there is no difference.
+    """
+    diff = difflib.unified_diff(
+        normalize_for_diff(running),
+        normalize_for_diff(candidate),
+        fromfile="running",
+        tofile="candidate",
+        n=context,
+        lineterm="",
+    )
+    return "\n".join(diff)
+
+
+def export_args(
+    *,
+    file: str,
+    compact: bool,
+    verbose: bool,
+    terse: bool,
+    show_sensitive: bool,
+) -> dict[str, ROSType]:
+    args: dict[str, ROSType] = {"file": file}
+    if compact:
+        args["compact"] = True
+    if verbose:
+        args["verbose"] = True
+    if terse:
+        args["terse"] = True
+    if show_sensitive:
+        args["show-sensitive"] = True
+    return args
+
+
+def export_command(path: str | None) -> str:
+    # RouterOS has no `path=` parameter; a scoped export runs from within the menu,
+    # e.g. `/ip/address/export`.
+    if path is None:
+        return "/export"
+    return pjoin("/", path, "export")
+
+
+def import_args(*, filename: str, verbose: bool, dry_run: bool) -> dict[str, ROSType]:
+    # RouterOS rejects dry-run unless verbose is also set.
+    if dry_run:
+        verbose = True
+    args: dict[str, ROSType] = {"file-name": filename}
+    if verbose:
+        args["verbose"] = True
+    if dry_run:
+        args["dry-run"] = True
+    return args
+
+
+def backup_save_args(*, name: str, password: str | None, dont_encrypt: bool) -> dict[str, ROSType]:
+    args: dict[str, ROSType] = {"name": name}
+    if password is not None:
+        args["password"] = password
+    elif dont_encrypt:
+        args["dont-encrypt"] = True
+    return args
+
+
+def backup_load_args(*, name: str, password: str | None) -> dict[str, ROSType]:
+    # /system/backup/load requires the password parameter even for an unencrypted
+    # backup (in which case it is an empty string).
+    return {"name": name, "password": password if password is not None else ""}
+
+
+def ros_quote(value: str) -> str:
+    """
+    Quote a value for safe embedding in a RouterOS console script string.
+
+    The scheduler ``on-event`` is executed as a RouterOS script, so a raw value
+    containing a space, ``;``, ``"``, ``\\``, ``$`` (variable substitution) or a control
+    character would otherwise produce a malformed command that only fails when the timer
+    fires. A raw newline in particular is not a valid RouterOS string literal.
+    """
+    escaped = (
+        value.replace("\\", "\\\\").replace('"', '\\"').replace("$", "\\$").replace("\r", "\\r").replace("\n", "\\n")
+    )
+    return f'"{escaped}"'
+
+
+def scheduler_args(*, name: str, backup: str, seconds: int, password: str | None, policy: str) -> dict[str, ROSType]:
+    # The password is mandatory for /system backup load, empty for an unencrypted backup.
+    # Both the backup name and password are quoted so special characters cannot break the
+    # script. ``backup`` may differ from the job ``name`` (it carries the persistent path).
+    on_event = (
+        f"/system backup load name={ros_quote(backup)} password={ros_quote(password if password is not None else '')}"
+    )
+    return {
+        "name": name,
+        "interval": f"{seconds}s",
+        "on-event": on_event,
+        "policy": policy,
+        "comment": ROLLBACK_COMMENT,
+    }
+
+
+def reset_args(*, filename: str, keep_users: bool, no_defaults: bool) -> dict[str, ROSType]:
+    args: dict[str, ROSType] = {"run-after-reset": filename}
+    if no_defaults:
+        args["no-defaults"] = True
+    if keep_users:
+        args["keep-users"] = True
+    return args
+
+
+class Config:
+    """
+    Configuration management helper bound to a synchronous :class:`~librouteros.api.Api`.
+
+    Obtain one via :meth:`~librouteros.api.Api.config` or ``Config(api=...)``.
+    """
+
+    def __init__(self, api: Api) -> None:
+        self.api: Api = api
+
+    # -- low level /file helpers ------------------------------------------------
+
+    def _version(self) -> tuple[int, ...]:
+        version = next(iter(self.api("/system/resource/print")))["version"]
+        return tuple(int(part) for part in str(version).split()[0].split("."))
+
+    def _file_contents(self, name: str) -> str:
+        rows = tuple(self.api.path("file").select(_SIZE, _CONTENTS).where(_NAME == name))
+        if not rows:
+            raise FileNotFoundError(f"File {name!r} not found on device.")
+        contents = rows[0].get("contents")
+        if contents is not None:
+            return str(contents)
+        # Files larger than the API's inline limit (~a few tens of KB) do not expose the
+        # 'contents' property; read them back in chunks. /file/read needs RouterOS 7.13+.
+        if self._version() < (7, 13):
+            raise NotImplementedError("Reading a file larger than the inline API limit requires RouterOS 7.13+.")
+        return self._file_read(name, int(rows[0].get("size") or 0))
+
+    def _file_read(self, name: str, size: int) -> str:
+        parts: list[str] = []
+        offset = 0
+        while offset < size:
+            data = self._read_chunk(name, offset)
+            if not data:
+                break
+            parts.append(data)
+            offset += len(data)
+        return "".join(parts)
+
+    def _read_chunk(self, name: str, offset: int) -> str:
+        args: dict[str, ROSType] = {"file": name, "offset": offset, "chunk-size": _READ_CHUNK}
+        for attempt in range(_READ_RETRIES):
+            try:
+                rows = list(self.api("/file/read", **args))
+                return str(rows[0].get("data", "")) if rows else ""
+            except TrapError:
+                # The file is not readable yet (just written by /export); back off.
+                if attempt == _READ_RETRIES - 1:
+                    raise
+                sleep(_READ_RETRY_DELAY)
+        return ""  # pragma: no cover
+
+    def _file_remove(self, name: str) -> None:
+        ids = tuple(row[".id"] for row in self.api.path("file").select(_ID).where(_NAME == name))
+        if ids:
+            self.api.path("file").remove(*(str(i) for i in ids))
+
+    def _safe_file_remove(self, name: str) -> None:
+        # Best-effort cleanup for finally blocks: must not mask the original error (e.g.
+        # the imported config just cut our own management access).
+        try:
+            self._file_remove(name)
+        except (LibRouterosError, OSError) as exc:
+            LOGGER.warning("Failed to remove temporary file %r: %s", name, exc)
+
+    def _has_flash(self) -> bool:
+        rows = tuple(self.api.path("file").select(_TYPE).where(_NAME == "flash"))
+        return any(row.get("type") == "directory" for row in rows)
+
+    def _persistent_path(self, filename: str) -> str:
+        # Devices with a 'flash' directory only persist files stored inside it.
+        return f"flash/{filename}" if self._has_flash() else filename
+
+    def _scheduler_remove(self, name: str) -> None:
+        # Only match our own job (name + comment), never a user job of the same name.
+        scheduler = self.api.path("system", "scheduler")
+        ids = tuple(row[".id"] for row in scheduler.select(_ID).where(And(_NAME == name, _COMMENT == ROLLBACK_COMMENT)))
+        if ids:
+            scheduler.remove(*(str(i) for i in ids))
+
+    # -- public api -------------------------------------------------------------
+
+    def export(
+        self,
+        *,
+        compact: bool = False,
+        verbose: bool = False,
+        terse: bool = False,
+        show_sensitive: bool = False,
+        path: str | None = None,
+    ) -> str:
+        """
+        Return the device configuration as text.
+
+        ``/export`` writes nothing to the API when run directly, so this exports to a
+        temporary file and reads its contents back. Newlines are normalized to ``\\n``;
+        the volatile timestamp header is left intact (use :func:`compare` or
+        :func:`strip_header` to normalize it away).
+
+        :param compact: Output only the modified configuration (RouterOS default).
+        :param verbose: Output the whole configuration including defaults.
+        :param terse: Output configuration as full single-line commands.
+        :param show_sensitive: Include sensitive data (passwords, keys). Hidden by default.
+        :param path: Limit export to a menu path, e.g. ``"ip/address"`` (runs
+            ``/ip/address/export``).
+        """
+        args = export_args(
+            file=EXPORT_FILE, compact=compact, verbose=verbose, terse=terse, show_sensitive=show_sensitive
+        )
+        # /export overwrites an existing file, so no need to remove it first.
+        tuple(self.api(export_command(path), **args))
+        try:
+            return normalize_newlines(self._file_contents(f"{EXPORT_FILE}.rsc"))
+        finally:
+            self._safe_file_remove(f"{EXPORT_FILE}.rsc")
+
+    def apply(
+        self,
+        text: str | None = None,
+        *,
+        filename: str | None = None,
+        verbose: bool = False,
+        dry_run: bool = False,
+    ) -> None:
+        """
+        Import (run) a RouterOS ``.rsc`` script.
+
+        Provide exactly one of ``text`` (uploaded to a temporary file first) or
+        ``filename`` (an ``.rsc`` already present on the device).
+
+        Import is not transactional: a syntax error aborts before any change is made,
+        but a valid-but-failing command applies earlier lines then stops. Errors are
+        raised as :class:`~librouteros.exceptions.TrapError` (with line/column). Use
+        :meth:`validate` to check a script first and :meth:`arm_rollback` for a net.
+
+        :param text: Configuration script to upload and run.
+        :param filename: Name of an ``.rsc`` file already on the device.
+        :param verbose: Execute and report each line individually.
+        :param dry_run: Simulate without applying (implies ``verbose``; RouterOS 7.16+).
+        """
+        if filename is not None and text is not None:
+            raise ValueError("Provide exactly one of 'text' or 'filename'.")
+        if filename is not None:
+            tuple(self.api("/import", **import_args(filename=filename, verbose=verbose, dry_run=dry_run)))
+        elif text is not None:
+            # /file/add fails if the file already exists, so remove any stale copy first.
+            self._file_remove(IMPORT_FILE)
+            self.api.path("file").add(name=IMPORT_FILE, contents=text)
+            try:
+                tuple(self.api("/import", **import_args(filename=IMPORT_FILE, verbose=verbose, dry_run=dry_run)))
+            finally:
+                self._safe_file_remove(IMPORT_FILE)
+        else:
+            raise ValueError("Provide exactly one of 'text' or 'filename'.")
+
+    def validate(self, text: str) -> None:
+        """
+        Dry-run a configuration script, raising on any error, without applying it.
+
+        Requires RouterOS 7.16+.
+        """
+        self.apply(text, verbose=True, dry_run=True)
+
+    def compare(self, candidate: str, *, context: int = 3, **export_kwargs: bool | str | None) -> str:
+        """
+        Return a unified diff between the running configuration and ``candidate``.
+
+        The running configuration is exported automatically. Extra keyword arguments
+        are forwarded to :meth:`export` (e.g. ``show_sensitive=True``).
+        """
+        running = self.export(**export_kwargs)  # type: ignore[arg-type]
+        return compare(running, candidate, context=context)
+
+    def backup_save(
+        self, name: str, *, password: str | None = None, dont_encrypt: bool = True, persistent: bool = False
+    ) -> None:
+        """
+        Save a binary backup (``name.backup``). Backups are same-device/same-version.
+
+        :param name: Backup file name (``.backup`` appended automatically).
+        :param password: Encrypt with this password. When omitted and ``dont_encrypt``
+            is true, the backup is left unencrypted.
+        :param dont_encrypt: Do not encrypt when no ``password`` is given.
+        :param persistent: Store under ``flash/`` on devices that keep a RAM disk at the
+            file-system root, so the backup survives a reboot.
+        """
+        target = self._persistent_path(name) if persistent else name
+        tuple(
+            self.api(
+                "/system/backup/save", **backup_save_args(name=target, password=password, dont_encrypt=dont_encrypt)
+            )
+        )
+
+    def backup_load(self, name: str, *, password: str | None = None, persistent: bool = False) -> None:
+        """
+        Load a binary backup. This reboots the device (the API connection will drop).
+
+        :param persistent: Resolve ``name`` the same way :meth:`backup_save` did with
+            ``persistent=True``.
+        """
+        target = self._persistent_path(name) if persistent else name
+        tuple(self.api("/system/backup/load", **backup_load_args(name=target, password=password)))
+
+    def backup_exists(self, name: str, *, persistent: bool = False) -> bool:
+        """Return whether ``name.backup`` exists on the device."""
+        target = self._persistent_path(name) if persistent else name
+        rows = tuple(self.api.path("file").select(_NAME).where(_NAME == f"{target}.backup"))
+        return len(rows) > 0
+
+    def arm_rollback(
+        self, seconds: int, *, name: str = ROLLBACK_NAME, password: str | None = None, policy: str = _ROLLBACK_POLICY
+    ) -> None:
+        """
+        Arm a device-side rollback that restores the current config after ``seconds``.
+
+        Saves a backup of the current state (to persistent storage so it survives a
+        reboot) and schedules a ``/system/scheduler`` job that reloads it, rebooting the
+        device. Call :meth:`cancel_rollback` to confirm/keep the new configuration before
+        the timer fires. Because the timer lives on the device it survives client death, a
+        lost session, or a lock-out, with no safe-mode action limit.
+
+        :param seconds: Delay before the automatic restore fires (a positive integer).
+        :param name: Backup and scheduler job name.
+        :param password: Optional backup password. Note: it is embedded in the scheduler
+            ``on-event`` (visible via export); prefer leaving it unset.
+        :param policy: Scheduler policy set. RouterOS refuses to create the job unless the
+            API user holds every listed policy; restricted accounts can narrow this.
+        """
+        if not isinstance(seconds, int) or seconds < 1:
+            raise ValueError("seconds must be a positive integer.")
+        # Remove any stale job BEFORE the backup so the backup cannot capture the
+        # rollback scheduler itself (which would reboot-loop when restored).
+        self._scheduler_remove(name)
+        backup = self._persistent_path(name)
+        self.backup_save(backup, password=password)
+        tuple(
+            self.api(
+                "/system/scheduler/add",
+                **scheduler_args(name=name, backup=backup, seconds=seconds, password=password, policy=policy),
+            )
+        )
+
+    def cancel_rollback(self, *, name: str = ROLLBACK_NAME) -> None:
+        """Cancel an armed rollback (the confirm path): remove the job and its backup."""
+        self._scheduler_remove(name)
+        self._file_remove(f"{self._persistent_path(name)}.backup")
+
+    def rollback_pending(self, *, name: str = ROLLBACK_NAME) -> bool:
+        """Return whether a rollback job armed by :meth:`arm_rollback` is still scheduled."""
+        scheduler = self.api.path("system", "scheduler")
+        rows = tuple(scheduler.select(_NAME).where(And(_NAME == name, _COMMENT == ROLLBACK_COMMENT)))
+        return len(rows) > 0
+
+    def replace(
+        self,
+        text: str,
+        *,
+        keep_users: bool = True,
+        no_defaults: bool = True,
+        name: str = REPLACE_NAME,
+    ) -> None:
+        """
+        Replace the whole configuration by wiping and rebooting into ``text``.
+
+        Uploads ``text`` to persistent storage and runs ``/system reset-configuration
+        run-after-reset=...``. This is destructive: the device wipes its configuration,
+        reboots, and replays the script (the API connection drops).
+
+        There is NO automatic rollback for a replace: safe mode is ignored for resets,
+        the run-after-reset script must finish within ~2 minutes, and with
+        ``no_defaults`` the script must fully establish management connectivity or the
+        device becomes unreachable. Ensure out-of-band (console/netinstall) recovery.
+
+        The script is imperative, so its ``add`` lines fail if the entity already
+        exists in whatever the reset leaves behind (e.g. an ``/ip dhcp-client add`` when
+        the platform re-creates a management dhcp-client after reset); such a failure
+        aborts the rest of the script. The candidate must match the post-reset state.
+
+        :param keep_users: Retain existing user accounts across the reset.
+        :param no_defaults: Do not lay down RouterOS factory defaults before the script.
+        :param name: Base name for the uploaded ``.rsc`` file.
+        """
+        filename = self._persistent_path(f"{name}.rsc")
+        # /file/add fails if the file already exists, so remove any stale copy first.
+        self._file_remove(filename)
+        self.api.path("file").add(name=filename, contents=text)
+        tuple(
+            self.api(
+                "/system/reset-configuration",
+                **reset_args(filename=filename, keep_users=keep_users, no_defaults=no_defaults),
+            )
+        )
+
+
+class AsyncConfig:
+    """
+    Configuration management helper bound to an :class:`~librouteros.api.AsyncApi`.
+
+    Async mirror of :class:`Config`; see it for method semantics.
+    """
+
+    def __init__(self, api: AsyncApi) -> None:
+        self.api: AsyncApi = api
+
+    async def _drain(self, cmd: str, /, **kwargs: ROSType) -> list[ReplyDict]:
+        return [row async for row in self.api(cmd, **kwargs)]
+
+    # -- low level /file helpers ------------------------------------------------
+
+    async def _version(self) -> tuple[int, ...]:
+        rows = [row async for row in self.api("/system/resource/print")]
+        return tuple(int(part) for part in str(rows[0]["version"]).split()[0].split("."))
+
+    async def _file_contents(self, name: str) -> str:
+        rows = [row async for row in self.api.path("file").select(_SIZE, _CONTENTS).where(_NAME == name)]
+        if not rows:
+            raise FileNotFoundError(f"File {name!r} not found on device.")
+        contents = rows[0].get("contents")
+        if contents is not None:
+            return str(contents)
+        # Large files do not expose 'contents'; read them in chunks. /file/read needs 7.13+.
+        if await self._version() < (7, 13):
+            raise NotImplementedError("Reading a file larger than the inline API limit requires RouterOS 7.13+.")
+        return await self._file_read(name, int(rows[0].get("size") or 0))
+
+    async def _file_read(self, name: str, size: int) -> str:
+        parts: list[str] = []
+        offset = 0
+        while offset < size:
+            data = await self._read_chunk(name, offset)
+            if not data:
+                break
+            parts.append(data)
+            offset += len(data)
+        return "".join(parts)
+
+    async def _read_chunk(self, name: str, offset: int) -> str:
+        args: dict[str, ROSType] = {"file": name, "offset": offset, "chunk-size": _READ_CHUNK}
+        for attempt in range(_READ_RETRIES):
+            try:
+                rows = await self._drain("/file/read", **args)
+                return str(rows[0].get("data", "")) if rows else ""
+            except TrapError:
+                # The file is not readable yet (just written by /export); back off.
+                if attempt == _READ_RETRIES - 1:
+                    raise
+                await asyncio.sleep(_READ_RETRY_DELAY)
+        return ""  # pragma: no cover
+
+    async def _file_remove(self, name: str) -> None:
+        ids = [row[".id"] async for row in self.api.path("file").select(_ID).where(_NAME == name)]
+        if ids:
+            await self.api.path("file").remove(*(str(i) for i in ids))
+
+    async def _safe_file_remove(self, name: str) -> None:
+        try:
+            await self._file_remove(name)
+        except (LibRouterosError, OSError) as exc:
+            LOGGER.warning("Failed to remove temporary file %r: %s", name, exc)
+
+    async def _has_flash(self) -> bool:
+        rows = [row async for row in self.api.path("file").select(_TYPE).where(_NAME == "flash")]
+        return any(row.get("type") == "directory" for row in rows)
+
+    async def _persistent_path(self, filename: str) -> str:
+        return f"flash/{filename}" if await self._has_flash() else filename
+
+    async def _scheduler_remove(self, name: str) -> None:
+        # Only match our own job (name + comment), never a user job of the same name.
+        scheduler = self.api.path("system", "scheduler")
+        ids = [
+            row[".id"] async for row in scheduler.select(_ID).where(And(_NAME == name, _COMMENT == ROLLBACK_COMMENT))
+        ]
+        if ids:
+            await scheduler.remove(*(str(i) for i in ids))
+
+    # -- public api -------------------------------------------------------------
+
+    async def export(
+        self,
+        *,
+        compact: bool = False,
+        verbose: bool = False,
+        terse: bool = False,
+        show_sensitive: bool = False,
+        path: str | None = None,
+    ) -> str:
+        """See :meth:`Config.export`."""
+        args = export_args(
+            file=EXPORT_FILE, compact=compact, verbose=verbose, terse=terse, show_sensitive=show_sensitive
+        )
+        # /export overwrites an existing file, so no need to remove it first.
+        await self._drain(export_command(path), **args)
+        try:
+            return normalize_newlines(await self._file_contents(f"{EXPORT_FILE}.rsc"))
+        finally:
+            await self._safe_file_remove(f"{EXPORT_FILE}.rsc")
+
+    async def apply(
+        self,
+        text: str | None = None,
+        *,
+        filename: str | None = None,
+        verbose: bool = False,
+        dry_run: bool = False,
+    ) -> None:
+        """See :meth:`Config.apply`."""
+        if filename is not None and text is not None:
+            raise ValueError("Provide exactly one of 'text' or 'filename'.")
+        if filename is not None:
+            await self._drain("/import", **import_args(filename=filename, verbose=verbose, dry_run=dry_run))
+        elif text is not None:
+            # /file/add fails if the file already exists, so remove any stale copy first.
+            await self._file_remove(IMPORT_FILE)
+            await self.api.path("file").add(name=IMPORT_FILE, contents=text)
+            try:
+                await self._drain("/import", **import_args(filename=IMPORT_FILE, verbose=verbose, dry_run=dry_run))
+            finally:
+                await self._safe_file_remove(IMPORT_FILE)
+        else:
+            raise ValueError("Provide exactly one of 'text' or 'filename'.")
+
+    async def validate(self, text: str) -> None:
+        """See :meth:`Config.validate`."""
+        await self.apply(text, verbose=True, dry_run=True)
+
+    async def compare(self, candidate: str, *, context: int = 3, **export_kwargs: bool | str | None) -> str:
+        """See :meth:`Config.compare`."""
+        running = await self.export(**export_kwargs)  # type: ignore[arg-type]
+        return compare(running, candidate, context=context)
+
+    async def backup_save(
+        self, name: str, *, password: str | None = None, dont_encrypt: bool = True, persistent: bool = False
+    ) -> None:
+        """See :meth:`Config.backup_save`."""
+        target = await self._persistent_path(name) if persistent else name
+        await self._drain(
+            "/system/backup/save", **backup_save_args(name=target, password=password, dont_encrypt=dont_encrypt)
+        )
+
+    async def backup_load(self, name: str, *, password: str | None = None, persistent: bool = False) -> None:
+        """See :meth:`Config.backup_load`."""
+        target = await self._persistent_path(name) if persistent else name
+        await self._drain("/system/backup/load", **backup_load_args(name=target, password=password))
+
+    async def backup_exists(self, name: str, *, persistent: bool = False) -> bool:
+        """See :meth:`Config.backup_exists`."""
+        target = await self._persistent_path(name) if persistent else name
+        rows = [row async for row in self.api.path("file").select(_NAME).where(_NAME == f"{target}.backup")]
+        return len(rows) > 0
+
+    async def arm_rollback(
+        self, seconds: int, *, name: str = ROLLBACK_NAME, password: str | None = None, policy: str = _ROLLBACK_POLICY
+    ) -> None:
+        """See :meth:`Config.arm_rollback`."""
+        if not isinstance(seconds, int) or seconds < 1:
+            raise ValueError("seconds must be a positive integer.")
+        # Remove any stale job BEFORE the backup so the backup cannot capture the
+        # rollback scheduler itself (which would reboot-loop when restored).
+        await self._scheduler_remove(name)
+        backup = await self._persistent_path(name)
+        await self.backup_save(backup, password=password)
+        await self._drain(
+            "/system/scheduler/add",
+            **scheduler_args(name=name, backup=backup, seconds=seconds, password=password, policy=policy),
+        )
+
+    async def cancel_rollback(self, *, name: str = ROLLBACK_NAME) -> None:
+        """See :meth:`Config.cancel_rollback`."""
+        await self._scheduler_remove(name)
+        await self._file_remove(f"{await self._persistent_path(name)}.backup")
+
+    async def rollback_pending(self, *, name: str = ROLLBACK_NAME) -> bool:
+        """See :meth:`Config.rollback_pending`."""
+        scheduler = self.api.path("system", "scheduler")
+        rows = [row async for row in scheduler.select(_NAME).where(And(_NAME == name, _COMMENT == ROLLBACK_COMMENT))]
+        return len(rows) > 0
+
+    async def replace(
+        self,
+        text: str,
+        *,
+        keep_users: bool = True,
+        no_defaults: bool = True,
+        name: str = REPLACE_NAME,
+    ) -> None:
+        """See :meth:`Config.replace`."""
+        filename = await self._persistent_path(f"{name}.rsc")
+        # /file/add fails if the file already exists, so remove any stale copy first.
+        await self._file_remove(filename)
+        await self.api.path("file").add(name=filename, contents=text)
+        await self._drain(
+            "/system/reset-configuration",
+            **reset_args(filename=filename, keep_users=keep_users, no_defaults=no_defaults),
+        )

--- a/tests/integration/test_config.py
+++ b/tests/integration/test_config.py
@@ -1,0 +1,156 @@
+import pytest
+
+from librouteros.config import ROLLBACK_NAME
+from librouteros.exceptions import TrapError
+from librouteros.query import Key
+
+# The config-management engine targets RouterOS 7.x. Some primitives used here
+# (notably /import dry-run) only exist on 7.16+, so skip on older devices.
+
+_NAME = Key("name")
+_ID = Key(".id")
+
+
+def _major(api):
+    resource = next(iter(api("/system/resource/print")))
+    return int(str(resource["version"]).split(".", 1)[0])
+
+
+def _skip_pre7(api):
+    if _major(api) < 7:
+        pytest.skip("config management requires RouterOS 7.x")
+
+
+def _addresses(api):
+    return [row.get("address") for row in api("/ip/address/print")]
+
+
+def _remove_addresses_with_comment(api, comment):
+    for row in api("/ip/address/print", **{".proplist": ".id,comment"}):
+        if row.get("comment") == comment:
+            tuple(api("/ip/address/remove", **{".id": row[".id"]}))
+
+
+def test_export_returns_running_config(routeros_api_sync):
+    api = routeros_api_sync
+    _skip_pre7(api)
+    config = api.config().export()
+    assert isinstance(config, str)
+    assert config.strip()
+    assert "\r\n" not in config  # newlines normalized
+    assert "# " in config  # export header present
+
+
+def test_apply_merge_then_visible(routeros_api_sync):
+    api = routeros_api_sync
+    _skip_pre7(api)
+    cfg = api.config()
+    comment = "librouteros-it-merge"
+    try:
+        cfg.apply(f"/ip address add address=10.99.1.1/24 interface=ether1 comment={comment}\r\n")
+        assert "10.99.1.1/24" in _addresses(api)
+    finally:
+        _remove_addresses_with_comment(api, comment)
+    assert "10.99.1.1/24" not in _addresses(api)
+
+
+def test_apply_bad_script_raises_and_changes_nothing(routeros_api_sync):
+    api = routeros_api_sync
+    _skip_pre7(api)
+    cfg = api.config()
+    before = _addresses(api)
+    with pytest.raises(TrapError):
+        cfg.apply("/ip address add address=10.99.2.1/24 interface=ether1\r\n/bogus/path set x=1\r\n")
+    # syntax error aborts the import before applying anything
+    assert _addresses(api) == before
+
+
+def test_validate_accepts_good_script(routeros_api_sync):
+    api = routeros_api_sync
+    _skip_pre7(api)
+    cfg = api.config()
+    before = _addresses(api)
+    cfg.validate("/ip address add address=10.99.3.1/24 interface=ether1\r\n")  # must not raise
+    assert _addresses(api) == before  # dry-run never applies anything
+
+
+def test_validate_rejects_bad_script(routeros_api_sync):
+    api = routeros_api_sync
+    _skip_pre7(api)
+    cfg = api.config()
+    before = _addresses(api)
+    with pytest.raises(TrapError):
+        cfg.validate("/bogus/path set x=1\r\n")
+    assert _addresses(api) == before  # nothing applied
+
+
+def test_compare_detects_added_line(routeros_api_sync):
+    api = routeros_api_sync
+    _skip_pre7(api)
+    cfg = api.config()
+    running = cfg.export()
+    candidate = running + "/ip address add address=10.99.4.1/24 interface=ether1\n"
+    diff = cfg.compare(candidate)
+    assert "+/ip address add address=10.99.4.1/24 interface=ether1" in diff
+
+
+def test_rollback_arm_pending_cancel(routeros_api_sync):
+    api = routeros_api_sync
+    _skip_pre7(api)
+    cfg = api.config()
+
+    def scheduler_names():
+        return [row.get("name") for row in api("/system/scheduler/print", **{".proplist": "name"})]
+
+    def file_names():
+        return [row.get("name") for row in api("/file/print", **{".proplist": "name"})]
+
+    assert cfg.rollback_pending() is False
+    try:
+        cfg.arm_rollback(300)
+        assert cfg.rollback_pending() is True
+        assert ROLLBACK_NAME in scheduler_names()
+        assert f"{ROLLBACK_NAME}.backup" in file_names()
+    finally:
+        cfg.cancel_rollback()
+    assert cfg.rollback_pending() is False
+    assert ROLLBACK_NAME not in scheduler_names()
+    assert f"{ROLLBACK_NAME}.backup" not in file_names()
+
+
+def test_export_leaves_no_temp_file(routeros_api_sync):
+    api = routeros_api_sync
+    _skip_pre7(api)
+    cfg = api.config()
+    cfg.export()
+    names = [str(row.get("name", "")) for row in api("/file/print", **{".proplist": "name"})]
+    assert not any(name.startswith("librouteros-export") for name in names)
+
+
+@pytest.mark.asyncio
+async def test_async_export_and_merge(routeros_api_async):
+    api = routeros_api_async
+    resource = await anext(api("/system/resource/print"))
+    if int(str(resource["version"]).split(".", 1)[0]) < 7:
+        pytest.skip("config management requires RouterOS 7.x")
+    cfg = api.config()
+    config = await cfg.export()
+    assert config.strip()
+
+    comment = "librouteros-it-async"
+    try:
+        await cfg.apply(f"/ip address add address=10.99.5.1/24 interface=ether1 comment={comment}\r\n")
+        addresses = [row.get("address") async for row in api("/ip/address/print")]
+        assert "10.99.5.1/24" in addresses
+    finally:
+        async for row in api("/ip/address/print", **{".proplist": ".id,comment"}):
+            if row.get("comment") == comment:
+                await api.path("ip", "address").remove(str(row[".id"]))
+
+
+@pytest.mark.skip(reason="destructive: reboots the device; run manually against a disposable device")
+def test_replace_reboots_into_new_config(routeros_api_sync):
+    api = routeros_api_sync
+    _skip_pre7(api)
+    cfg = api.config()
+    cfg.replace(cfg.export() + "/system identity set name=REPLACED\r\n")

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,0 +1,507 @@
+# -*- coding: UTF-8 -*-
+
+from unittest.mock import (
+    AsyncMock,
+    MagicMock,
+    call,
+)
+
+import pytest
+
+from librouteros.api import Api, AsyncApi, Path
+from librouteros.config import (
+    EXPORT_FILE,
+    IMPORT_FILE,
+    ROLLBACK_COMMENT,
+    ROLLBACK_NAME,
+    AsyncConfig,
+    Config,
+    backup_load_args,
+    backup_save_args,
+    compare,
+    export_args,
+    export_command,
+    import_args,
+    reset_args,
+    ros_quote,
+    scheduler_args,
+    strip_header,
+)
+from librouteros.exceptions import ConnectionClosed, TrapError
+
+# --------------------------------------------------------------------------- #
+# Pure argument builders (the RouterOS command contract)
+# --------------------------------------------------------------------------- #
+
+
+def test_export_args_default():
+    assert export_args(file="x", compact=False, verbose=False, terse=False, show_sensitive=False) == {"file": "x"}
+
+
+def test_export_args_all_flags():
+    assert export_args(file="x", compact=True, verbose=True, terse=True, show_sensitive=True) == {
+        "file": "x",
+        "compact": True,
+        "verbose": True,
+        "terse": True,
+        "show-sensitive": True,
+    }
+
+
+@pytest.mark.parametrize(
+    ("path", "command"),
+    (
+        (None, "/export"),
+        ("ip/address", "/ip/address/export"),
+        ("/ip/address/", "/ip/address/export"),
+    ),
+)
+def test_export_command(path, command):
+    # RouterOS has no path= parameter; a scoped export runs from within the menu.
+    assert export_command(path) == command
+
+
+def test_import_args_plain():
+    assert import_args(filename="x.rsc", verbose=False, dry_run=False) == {"file-name": "x.rsc"}
+
+
+def test_import_args_verbose():
+    assert import_args(filename="x.rsc", verbose=True, dry_run=False) == {"file-name": "x.rsc", "verbose": True}
+
+
+def test_import_args_dry_run_implies_verbose():
+    """RouterOS rejects dry-run unless verbose is also set."""
+    assert import_args(filename="x.rsc", verbose=False, dry_run=True) == {
+        "file-name": "x.rsc",
+        "verbose": True,
+        "dry-run": True,
+    }
+
+
+def test_backup_save_args_unencrypted_by_default():
+    assert backup_save_args(name="b", password=None, dont_encrypt=True) == {"name": "b", "dont-encrypt": True}
+
+
+def test_backup_save_args_password_wins_over_dont_encrypt():
+    assert backup_save_args(name="b", password="pw", dont_encrypt=True) == {"name": "b", "password": "pw"}  # noqa S106
+
+
+def test_backup_save_args_encrypted_no_password():
+    assert backup_save_args(name="b", password=None, dont_encrypt=False) == {"name": "b"}
+
+
+def test_backup_load_args_requires_password_field():
+    # /system/backup/load needs the password parameter even when unencrypted (empty).
+    assert backup_load_args(name="b", password=None) == {"name": "b", "password": ""}
+    assert backup_load_args(name="b", password="pw") == {"name": "b", "password": "pw"}  # noqa S106
+
+
+def test_scheduler_args():
+    args = scheduler_args(name=ROLLBACK_NAME, backup=ROLLBACK_NAME, seconds=300, password=None, policy="reboot,read")
+    assert args["name"] == ROLLBACK_NAME
+    assert args["interval"] == "300s"
+    assert args["on-event"] == f'/system backup load name="{ROLLBACK_NAME}" password=""'
+    assert args["policy"] == "reboot,read"
+
+
+def test_scheduler_args_loads_the_resolved_backup_path():
+    # The job name and the backup file can differ (backup carries the persistent path).
+    args = scheduler_args(name=ROLLBACK_NAME, backup="flash/rb", seconds=10, password=None, policy="reboot")
+    assert args["on-event"] == '/system backup load name="flash/rb" password=""'
+
+
+def test_scheduler_args_password_embedded():
+    args = scheduler_args(name=ROLLBACK_NAME, backup=ROLLBACK_NAME, seconds=10, password="pw", policy="reboot")  # noqa S106
+    assert args["on-event"] == f'/system backup load name="{ROLLBACK_NAME}" password="pw"'
+
+
+@pytest.mark.parametrize(
+    ("value", "quoted"),
+    (
+        ("plain", '"plain"'),
+        ("pre upgrade", '"pre upgrade"'),
+        ("a$b", '"a\\$b"'),
+        ('a"b', '"a\\"b"'),
+        ("a\\b", '"a\\\\b"'),
+        ("a\nb", '"a\\nb"'),
+        ("a\rb", '"a\\rb"'),
+    ),
+)
+def test_ros_quote_escapes_script_special_chars(value, quoted):
+    assert ros_quote(value) == quoted
+
+
+def test_scheduler_args_quotes_special_chars():
+    # A password containing '$' must not break the on-event script.
+    args = scheduler_args(name="pre upgrade", backup="pre upgrade", seconds=10, password="p$ss", policy="reboot")  # noqa S106
+    assert args["on-event"] == '/system backup load name="pre upgrade" password="p\\$ss"'
+
+
+def test_reset_args_defaults():
+    assert reset_args(filename="flash/x.rsc", keep_users=True, no_defaults=True) == {
+        "run-after-reset": "flash/x.rsc",
+        "no-defaults": True,
+        "keep-users": True,
+    }
+
+
+def test_reset_args_minimal():
+    assert reset_args(filename="x.rsc", keep_users=False, no_defaults=False) == {"run-after-reset": "x.rsc"}
+
+
+# --------------------------------------------------------------------------- #
+# Diff / normalization helpers
+# --------------------------------------------------------------------------- #
+
+
+def test_strip_header():
+    text = "# 2026-07-11 21:04:13 by RouterOS 7.21.5\n/ip address\n"
+    assert strip_header(text) == "# by RouterOS 7.21.5\n/ip address\n"
+
+
+def test_compare_identical_is_empty():
+    cfg = "/ip address\nadd address=1.1.1.1/24\n"
+    assert compare(cfg, cfg) == ""
+
+
+def test_compare_ignores_header_and_crlf():
+    a = "# 2026-01-01 00:00:00 by RouterOS 7.21.5\r\n/ip address\r\n"
+    b = "# 2020-05-05 12:00:00 by RouterOS 7.21.5\n/ip address\n"
+    assert compare(a, b) == ""
+
+
+def test_compare_shows_added_line():
+    a = "/ip address\nadd address=1.1.1.1/24\n"
+    b = "/ip address\nadd address=1.1.1.1/24\nadd address=2.2.2.2/24\n"
+    diff = compare(a, b)
+    assert "+add address=2.2.2.2/24" in diff
+    assert diff.startswith("--- running")
+
+
+# --------------------------------------------------------------------------- #
+# Config orchestration (helpers mocked; verify command flow + cleanup)
+# --------------------------------------------------------------------------- #
+
+
+def _config_with_mocked_helpers():
+    cfg = Config(api=MagicMock(return_value=[]))
+    cfg._file_remove = MagicMock()
+    cfg._file_contents = MagicMock(return_value="line1\r\nline2\r\n")
+    cfg._scheduler_remove = MagicMock()
+    cfg._persistent_path = MagicMock(side_effect=lambda name: f"flash/{name}")
+    return cfg
+
+
+def test_export_reads_and_cleans_up():
+    cfg = _config_with_mocked_helpers()
+    result = cfg.export()
+    assert result == "line1\nline2\n"  # newlines normalized, header untouched
+    cfg.api.assert_called_once_with("/export", file=EXPORT_FILE)
+    # /export overwrites, so the file is only removed afterwards (cleanup)
+    cfg._file_remove.assert_called_once_with(f"{EXPORT_FILE}.rsc")
+    cfg._file_contents.assert_called_once_with(f"{EXPORT_FILE}.rsc")
+
+
+def test_export_passes_flags():
+    cfg = _config_with_mocked_helpers()
+    cfg.export(terse=True, show_sensitive=True)
+    cfg.api.assert_called_once_with("/export", file=EXPORT_FILE, terse=True, **{"show-sensitive": True})
+
+
+def test_export_scoped_path_uses_menu_command():
+    cfg = _config_with_mocked_helpers()
+    cfg.export(path="ip/address")
+    cfg.api.assert_called_once_with("/ip/address/export", file=EXPORT_FILE)
+
+
+def test_apply_text_uploads_imports_and_cleans_up():
+    cfg = _config_with_mocked_helpers()
+    cfg.apply("/ip address add address=1.1.1.1/24\n")
+    cfg.api.path.return_value.add.assert_called_once_with(
+        name=IMPORT_FILE, contents="/ip address add address=1.1.1.1/24\n"
+    )
+    cfg.api.assert_called_once_with("/import", **{"file-name": IMPORT_FILE})
+    # stale removed before add, temp removed after import
+    assert cfg._file_remove.call_args_list == [call(IMPORT_FILE), call(IMPORT_FILE)]
+
+
+def test_apply_text_cleans_up_even_on_error():
+    cfg = _config_with_mocked_helpers()
+    cfg.api = MagicMock(side_effect=TrapError(message="Script Error"))
+    with pytest.raises(TrapError):
+        cfg.apply("/bogus\n")
+    # temp file still removed in the finally block
+    assert call(IMPORT_FILE) in cfg._file_remove.call_args_list
+    assert cfg._file_remove.call_args_list[-1] == call(IMPORT_FILE)
+
+
+def test_apply_filename_does_not_upload_or_clean():
+    cfg = _config_with_mocked_helpers()
+    cfg.apply(filename="onbox.rsc")
+    cfg.api.path.return_value.add.assert_not_called()
+    cfg._file_remove.assert_not_called()
+    cfg.api.assert_called_once_with("/import", **{"file-name": "onbox.rsc"})
+
+
+def test_apply_finally_does_not_mask_original_error():
+    # If the imported config cuts our own access, the finally cleanup fails too; the
+    # original import error must still propagate, not the cleanup's ConnectionClosed.
+    cfg = _config_with_mocked_helpers()
+    cfg.api = MagicMock(side_effect=TrapError(message="import failed"))
+    # stale-removal (1st call) succeeds; the finally cleanup (2nd call) fails
+    cfg._file_remove = MagicMock(side_effect=[None, ConnectionClosed("connection dropped")])
+    with pytest.raises(TrapError, match="import failed"):
+        cfg.apply("/some/config\n")
+
+
+@pytest.mark.parametrize(
+    ("text", "filename"),
+    (
+        (None, None),
+        ("cfg", "file.rsc"),
+    ),
+)
+def test_apply_rejects_ambiguous_source(text, filename):
+    cfg = _config_with_mocked_helpers()
+    with pytest.raises(ValueError, match="exactly one"):
+        cfg.apply(text, filename=filename)
+
+
+def test_validate_is_dry_run():
+    cfg = _config_with_mocked_helpers()
+    cfg.apply = MagicMock()
+    cfg.validate("/ip address\n")
+    cfg.apply.assert_called_once_with("/ip address\n", verbose=True, dry_run=True)
+
+
+def test_backup_save_and_load_commands():
+    cfg = _config_with_mocked_helpers()
+    cfg.backup_save("snap")
+    cfg.api.assert_called_with("/system/backup/save", name="snap", **{"dont-encrypt": True})
+    cfg.api.reset_mock()
+    cfg.backup_load("snap")
+    cfg.api.assert_called_with("/system/backup/load", name="snap", password="")
+
+
+def test_backup_save_persistent_uses_flash_path():
+    cfg = _config_with_mocked_helpers()  # _persistent_path mock prepends "flash/"
+    cfg.backup_save("snap", persistent=True)
+    cfg.api.assert_called_once_with("/system/backup/save", name="flash/snap", **{"dont-encrypt": True})
+
+
+def test_backup_load_persistent_uses_flash_path():
+    cfg = _config_with_mocked_helpers()
+    cfg.backup_load("snap", persistent=True)
+    cfg.api.assert_called_once_with("/system/backup/load", name="flash/snap", password="")
+
+
+def test_arm_rollback_saves_backup_and_adds_scheduler():
+    cfg = _config_with_mocked_helpers()
+    cfg.arm_rollback(300)
+    calls = [c.args[0] for c in cfg.api.call_args_list]
+    assert calls == ["/system/backup/save", "/system/scheduler/add"]
+    cfg._scheduler_remove.assert_called_once_with(ROLLBACK_NAME)
+    sched_kwargs = cfg.api.call_args_list[-1].kwargs
+    assert sched_kwargs["name"] == ROLLBACK_NAME
+    assert sched_kwargs["interval"] == "300s"
+
+
+@pytest.mark.parametrize("bad", (0, -5, 0.5, 30.0))
+def test_arm_rollback_rejects_non_positive_or_fractional(bad):
+    # A fractional value would truncate to interval=0s and never fire.
+    cfg = _config_with_mocked_helpers()
+    with pytest.raises(ValueError, match="positive integer"):
+        cfg.arm_rollback(bad)
+
+
+def test_arm_rollback_removes_stale_job_before_backup():
+    # The stale scheduler must be removed before the backup is taken, otherwise the
+    # backup captures the rollback job and restoring it reboot-loops.
+    cfg = _config_with_mocked_helpers()
+    manager = MagicMock()
+    cfg._scheduler_remove = manager.scheduler_remove
+    cfg.backup_save = manager.backup_save
+    cfg.arm_rollback(60)
+    ordered = [c[0] for c in manager.mock_calls]
+    assert ordered.index("scheduler_remove") < ordered.index("backup_save")
+
+
+def test_cancel_rollback_removes_scheduler_and_persistent_backup():
+    cfg = _config_with_mocked_helpers()  # _persistent_path mock prepends "flash/"
+    cfg.cancel_rollback()
+    cfg._scheduler_remove.assert_called_once_with(ROLLBACK_NAME)
+    cfg._file_remove.assert_called_once_with(f"flash/{ROLLBACK_NAME}.backup")
+
+
+def test_replace_uploads_then_resets():
+    cfg = _config_with_mocked_helpers()
+    cfg.replace("/ip address add address=1.1.1.1/24\n")
+    cfg._persistent_path.assert_called_once_with("librouteros-replace.rsc")
+    cfg.api.path.return_value.add.assert_called_once_with(
+        name="flash/librouteros-replace.rsc", contents="/ip address add address=1.1.1.1/24\n"
+    )
+    cfg.api.assert_called_once_with(
+        "/system/reset-configuration",
+        **{"run-after-reset": "flash/librouteros-replace.rsc", "no-defaults": True, "keep-users": True},
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Query-builder helpers, exercised through a small filtering fake
+# --------------------------------------------------------------------------- #
+
+
+class FilteringFake:
+    """
+    Minimal fake Api that serves ``*/print`` queries built by the query DSL and
+    records ``*/remove`` calls. Real librouteros Path/Query run on top of it.
+    """
+
+    def __init__(self, rows, blobs=None, version="7.21.5"):
+        self.rows = rows  # {"/file/print": [ {...}, ... ]}
+        self.blobs = blobs or {}  # {name: full-text} served by /file/read
+        self.version = version
+        self.removed = []
+
+    def rawCmd(self, cmd, *words):
+        filters = []
+        for word in words:
+            if word.startswith("?="):
+                _, key, value = word.split("=", 2)
+                filters.append((key, value))
+        return iter([row for row in self.rows.get(cmd, []) if all(str(row.get(k)) == v for k, v in filters)])
+
+    def __call__(self, cmd, **kwargs):
+        if cmd == "/system/resource/print":
+            return iter([{"version": self.version}])
+        if cmd == "/file/read":
+            blob = self.blobs.get(kwargs["file"], "")
+            offset, size = kwargs["offset"], kwargs["chunk-size"]
+            return iter([{"data": blob[offset : offset + size]}])
+        if cmd.endswith("/remove"):
+            self.removed.append(kwargs)
+        return iter([])
+
+    def path(self, *path):
+        return Path(path="", api=self).join(*path)
+
+
+def test_file_contents_returns_value():
+    fake = FilteringFake({"/file/print": [{".id": "*1", "name": "a.rsc", "contents": "hello"}]})
+    assert Config(api=fake)._file_contents("a.rsc") == "hello"
+
+
+def test_file_contents_missing_raises():
+    fake = FilteringFake({"/file/print": []})
+    with pytest.raises(FileNotFoundError):
+        Config(api=fake)._file_contents("missing.rsc")
+
+
+def test_file_contents_large_file_reads_in_chunks():
+    # Big files omit the 'contents' attribute; must chunk-read, never return "".
+    big = "".join(f"line {i}\n" for i in range(20000))  # > _READ_CHUNK bytes
+    fake = FilteringFake(
+        {"/file/print": [{".id": "*1", "name": "big.rsc", "size": len(big)}]},  # no 'contents'
+        blobs={"big.rsc": big},
+    )
+    assert Config(api=fake)._file_contents("big.rsc") == big
+
+
+def test_file_contents_large_file_pre_7_13_raises():
+    # /file/read is 7.13+; on older versions reading a big file must not silently return "".
+    fake = FilteringFake(
+        {"/file/print": [{".id": "*1", "name": "big.rsc", "size": 999999}]},  # no 'contents'
+        version="7.12.0",
+    )
+    with pytest.raises(NotImplementedError, match=r"7\.13"):
+        Config(api=fake)._file_contents("big.rsc")
+
+
+def test_backup_exists():
+    present = FilteringFake({"/file/print": [{".id": "*1", "name": "snap.backup"}]})
+    absent = FilteringFake({"/file/print": []})
+    assert Config(api=present).backup_exists("snap") is True
+    assert Config(api=absent).backup_exists("snap") is False
+
+
+def test_file_remove_removes_by_id():
+    fake = FilteringFake({"/file/print": [{".id": "*7", "name": "a.rsc"}]})
+    Config(api=fake)._file_remove("a.rsc")
+    assert fake.removed == [{".id": "*7"}]
+
+
+def test_file_remove_absent_is_noop():
+    fake = FilteringFake({"/file/print": []})
+    Config(api=fake)._file_remove("a.rsc")
+    assert fake.removed == []
+
+
+def test_rollback_pending_matches_our_job():
+    present = FilteringFake(
+        {"/system/scheduler/print": [{".id": "*1", "name": ROLLBACK_NAME, "comment": ROLLBACK_COMMENT}]}
+    )
+    absent = FilteringFake({"/system/scheduler/print": []})
+    assert Config(api=present).rollback_pending() is True
+    assert Config(api=absent).rollback_pending() is False
+
+
+def test_rollback_pending_ignores_foreign_job_with_same_name():
+    # A user scheduler that happens to share the reserved name is not ours.
+    foreign = FilteringFake({"/system/scheduler/print": [{".id": "*1", "name": ROLLBACK_NAME, "comment": "user job"}]})
+    assert Config(api=foreign).rollback_pending() is False
+
+
+def test_has_flash_detection():
+    withflash = FilteringFake({"/file/print": [{".id": "*1", "name": "flash", "type": "directory"}]})
+    without = FilteringFake({"/file/print": []})
+    assert Config(api=withflash)._persistent_path("x.rsc") == "flash/x.rsc"
+    assert Config(api=without)._persistent_path("x.rsc") == "x.rsc"
+
+
+# --------------------------------------------------------------------------- #
+# Async parity (helpers mocked)
+# --------------------------------------------------------------------------- #
+
+
+async def test_async_export_orchestration():
+    cfg = AsyncConfig(api=MagicMock())
+    cfg._drain = AsyncMock(return_value=[])
+    cfg._file_remove = AsyncMock()
+    cfg._file_contents = AsyncMock(return_value="a\r\nb\r\n")
+    result = await cfg.export()
+    assert result == "a\nb\n"
+    cfg._drain.assert_awaited_once_with("/export", file=EXPORT_FILE)
+    cfg._file_contents.assert_awaited_once_with(f"{EXPORT_FILE}.rsc")
+
+
+async def test_async_arm_rollback_removes_stale_job_before_backup():
+    # Async mirror of the sync ordering fix: remove the stale job before the backup.
+    cfg = AsyncConfig(api=MagicMock())
+    cfg._drain = AsyncMock(return_value=[])
+    order = []
+    cfg._scheduler_remove = AsyncMock(side_effect=lambda *a, **k: order.append("remove"))
+    cfg.backup_save = AsyncMock(side_effect=lambda *a, **k: order.append("backup"))
+    await cfg.arm_rollback(60)
+    assert order == ["remove", "backup"]
+
+
+async def test_async_apply_uploads_and_cleans_up():
+    cfg = AsyncConfig(api=MagicMock())
+    cfg._drain = AsyncMock(return_value=[])
+    cfg._file_remove = AsyncMock()
+    cfg.api.path.return_value.add = AsyncMock()
+    await cfg.apply("/ip address add address=1.1.1.1/24\n")
+    cfg.api.path.return_value.add.assert_awaited_once_with(
+        name=IMPORT_FILE, contents="/ip address add address=1.1.1.1/24\n"
+    )
+    cfg._drain.assert_awaited_once_with("/import", **{"file-name": IMPORT_FILE})
+
+
+def test_api_config_accessor_returns_config():
+    cfg = Api(protocol=MagicMock()).config()
+    assert isinstance(cfg, Config)
+
+
+def test_async_api_config_accessor_returns_async_config():
+    cfg = AsyncApi(protocol=MagicMock()).config()
+    assert isinstance(cfg, AsyncConfig)


### PR DESCRIPTION
## Summary

Adds a configuration management layer to librouteros, reachable via `api.config()`,
for RouterOS 7.x. It is implemented entirely over the binary API -- no SSH/terminal
access is required -- and adds no runtime dependencies (stdlib `difflib` only).

`Config` (sync) and `AsyncConfig` (async) provide:

- `export()` -- read the running config. `/export` returns nothing when run directly
  over the API, so this exports to a temporary file and reads it back.
- `apply()` / `validate()` -- `/import` a `.rsc` script, or dry-run it (`verbose` +
  `dry-run`, RouterOS 7.16+). Errors surface as `TrapError` with line and column.
- `compare()` -- unified diff of running vs candidate (informational; the module-level
  `compare()` diffs two strings directly).
- `backup_save()` / `backup_load()`.
- `arm_rollback()` / `cancel_rollback()` / `rollback_pending()` -- a device-side
  `/system/scheduler` + backup dead man's switch (commit-confirm style). Because the
  timer lives on the device it survives a lost session or a lock-out, with no safe-mode
  action limit.
- `replace()` -- `/system reset-configuration run-after-reset` (wipe + reboot into a
  new config).

## Why

Configuration management on RouterOS has historically been considered impractical over
the API (no `config replace`, no commit/rollback, safe mode is terminal-only). On
RouterOS 7.x the API is actually sufficient: `/export file=...` followed by reading the
`/file` `contents` retrieves a full export, `/file/add` + `/import` applies a script
(with errors reported), and a scheduler-based backup restore provides a rollback net
that survives a lock-out without needing safe mode.

## Design notes

- No diff engine. Applying a config needs no computed patch (`/import` runs the
  script's own actions). `compare()` is a plain textual diff for humans, not an
  executable patch, so it cannot silently misapply.
- RouterOS has no native non-reboot commit/rollback, so the rollback timer lives on the
  device (a one-shot `/system/scheduler` that restores a backup), not on the client --
  it fires even if the client process dies.
- `replace()` is destructive and has no automatic rollback (safe mode is ignored for
  resets, the run-after-reset script must finish within ~2 minutes); documented as such.

## Testing

- Unit tests (`tests/unit/test_config.py`): argument construction for every RouterOS
  command, diff/normalization logic, orchestration + temp-file cleanup (mocked helpers),
  and the query-builder helpers.
- Integration tests (`tests/integration/test_config.py`): export round-trip, merge
  apply, dry-run validation, compare, and the arm/pending/cancel rollback lifecycle,
  both sync and async, gated to RouterOS 7.x.
- Verified end to end against a CHR 7.21.5 instance, including the `replace()` reboot.
- `ruff check`, `ruff format --check` and `mypy` are clean.

Sync/async parity is maintained throughout. Documentation added at `docs/config.rst`.
