### PR TITLE
Close the transport when login fails in connect()

### DIFF
--- a/src/librouteros/__init__.py
+++ b/src/librouteros/__init__.py
@@ -15,7 +15,6 @@ from librouteros.config import (
     compare,  # noqa F401
 )
 from librouteros.connections import AsyncSocketTransport, SocketTransport
-from librouteros.exceptions import ConnectionClosed, FatalError
 from librouteros.login import (
     async_plain,
     async_token,  # noqa F401
@@ -100,12 +99,14 @@ def connect(
     protocol: ApiProtocol = ApiProtocol(transport=transport, encoding=encoding)
     api: Api = subclass(protocol=protocol)
 
+    logged_in = False
     try:
         login_method(api, username, password)
+        logged_in = True
         return api
-    except (ConnectionClosed, FatalError):
-        transport.close()
-        raise
+    finally:
+        if not logged_in:
+            transport.close()
 
 
 async def async_connect(
@@ -142,12 +143,14 @@ async def async_connect(
     protocol: AsyncApiProtocol = AsyncApiProtocol(transport=transport, encoding=encoding, timeout=timeout)
     api: AsyncApi = subclass(protocol=protocol)
 
+    logged_in = False
     try:
         await login_method(api, username, password)
+        logged_in = True
         return api
-    except (ConnectionClosed, FatalError):
-        await transport.close()
-        raise
+    finally:
+        if not logged_in:
+            await transport.close()
 
 
 def create_transport(

--- a/tests/unit/test_librouteros.py
+++ b/tests/unit/test_librouteros.py
@@ -1,6 +1,7 @@
 # -*- coding: UTF-8 -*-
 import socket
 from unittest.mock import (
+    AsyncMock,
     Mock,
     call,
     patch,
@@ -149,6 +150,38 @@ async def test_async_connect_raises_when_failed_login(transport_mock):
     failed = Mock(name="failed", side_effect=TrapError(message="failed to login"))
     with pytest.raises(TrapError):
         await async_connect(host="127.0.0.1", username="admin", password="", login_method=failed)
+
+
+@patch("librouteros.create_transport")
+def test_connect_closes_transport_on_failed_login(transport_mock):
+    # A failed login must not leak the open socket.
+    failed = Mock(name="failed", side_effect=TrapError(message="failed to login"))
+    with pytest.raises(TrapError):
+        connect(host="127.0.0.1", username="admin", password="", login_method=failed)
+    transport_mock.return_value.close.assert_called_once_with()
+
+
+@patch("librouteros.create_transport")
+def test_connect_does_not_close_transport_on_success(transport_mock):
+    # A successful login keeps the transport open for the returned Api.
+    connect(host="127.0.0.1", username="admin", password="", login_method=Mock(name="ok"))
+    transport_mock.return_value.close.assert_not_called()
+
+
+@pytest.mark.asyncio
+@patch("librouteros.async_create_transport")
+async def test_async_connect_closes_transport_on_failed_login(transport_mock):
+    failed = Mock(name="failed", side_effect=TrapError(message="failed to login"))
+    with pytest.raises(TrapError):
+        await async_connect(host="127.0.0.1", username="admin", password="", login_method=failed)
+    transport_mock.return_value.close.assert_awaited_once_with()
+
+
+@pytest.mark.asyncio
+@patch("librouteros.async_create_transport")
+async def test_async_connect_does_not_close_transport_on_success(transport_mock):
+    await async_connect(host="127.0.0.1", username="admin", password="", login_method=AsyncMock(name="ok"))
+    transport_mock.return_value.close.assert_not_awaited()
 
 
 @pytest.mark.parametrize("exc", (socket.error, socket.timeout))


### PR DESCRIPTION
`connect()` / `async_connect()` closed the transport only on `ConnectionClosed` / `FatalError`, so a failed login leaked the socket, one per attempt (bad credentials raise `TrapError`, a mid-login timeout raises `TimeoutError` / `OSError`). Close it on any failure with `try` / `finally`.

Validated on a RouterOS 7.21.5 CHR: 15 bad-credential connects leaked 15 sockets before, 0 after (sync + async); a good login still works. 218 unit tests pass.
