### PR TITLE
Harden the config export read path

### DIFF
--- a/src/librouteros/config.py
+++ b/src/librouteros/config.py
@@ -50,6 +50,22 @@ _READ_CHUNK = 32768
 _READ_RETRIES = 6
 _READ_RETRY_DELAY = 0.2
 
+# Leading integer of a version component. RouterOS testing builds tag the component
+# (e.g. "7.16rc1"), which a plain int() would choke on.
+_VERSION_PART = re.compile(r"\d+")
+
+
+def parse_version(version: str) -> tuple[int, ...]:
+    """Parse a RouterOS version string such as ``"7.16rc1 (testing)"`` into ``(7, 16)``."""
+    parts: list[int] = []
+    for part in version.split()[0].split("."):
+        match = _VERSION_PART.match(part)
+        if match is None:
+            break
+        parts.append(int(match.group()))
+    return tuple(parts)
+
+
 # Marks the rollback scheduler as ours so a user job that happens to share the reserved
 # name is not mistaken for it (and never removed by cancel_rollback).
 ROLLBACK_COMMENT = "librouteros rollback dead man switch"
@@ -215,7 +231,7 @@ class Config:
 
     def _version(self) -> tuple[int, ...]:
         version = next(iter(self.api("/system/resource/print")))["version"]
-        return tuple(int(part) for part in str(version).split()[0].split("."))
+        return parse_version(str(version))
 
     def _file_contents(self, name: str) -> str:
         rows = tuple(self.api.path("file").select(_SIZE, _CONTENTS).where(_NAME == name))
@@ -234,11 +250,11 @@ class Config:
         parts: list[str] = []
         offset = 0
         while offset < size:
-            data = self._read_chunk(name, offset)
-            if not data:
-                break
-            parts.append(data)
-            offset += len(data)
+            parts.append(self._read_chunk(name, offset))
+            # /file/read serves at most _READ_CHUNK bytes per call. Advance by the byte
+            # count requested, not len(str): under a multibyte encoding the two diverge and
+            # advancing by the shorter string length would re-read overlapping data.
+            offset += min(_READ_CHUNK, size - offset)
         return "".join(parts)
 
     def _read_chunk(self, name: str, offset: int) -> str:
@@ -513,7 +529,7 @@ class AsyncConfig:
 
     async def _version(self) -> tuple[int, ...]:
         rows = [row async for row in self.api("/system/resource/print")]
-        return tuple(int(part) for part in str(rows[0]["version"]).split()[0].split("."))
+        return parse_version(str(rows[0]["version"]))
 
     async def _file_contents(self, name: str) -> str:
         rows = [row async for row in self.api.path("file").select(_SIZE, _CONTENTS).where(_NAME == name)]
@@ -531,11 +547,11 @@ class AsyncConfig:
         parts: list[str] = []
         offset = 0
         while offset < size:
-            data = await self._read_chunk(name, offset)
-            if not data:
-                break
-            parts.append(data)
-            offset += len(data)
+            parts.append(await self._read_chunk(name, offset))
+            # /file/read serves at most _READ_CHUNK bytes per call. Advance by the byte
+            # count requested, not len(str): under a multibyte encoding the two diverge and
+            # advancing by the shorter string length would re-read overlapping data.
+            offset += min(_READ_CHUNK, size - offset)
         return "".join(parts)
 
     async def _read_chunk(self, name: str, offset: int) -> str:

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -10,6 +10,7 @@ import pytest
 
 from librouteros.api import Api, AsyncApi, Path
 from librouteros.config import (
+    _READ_CHUNK,
     EXPORT_FILE,
     IMPORT_FILE,
     ROLLBACK_COMMENT,
@@ -22,6 +23,7 @@ from librouteros.config import (
     export_args,
     export_command,
     import_args,
+    parse_version,
     reset_args,
     ros_quote,
     scheduler_args,
@@ -415,6 +417,53 @@ def test_file_contents_large_file_pre_7_13_raises():
     )
     with pytest.raises(NotImplementedError, match=r"7\.13"):
         Config(api=fake)._file_contents("big.rsc")
+
+
+@pytest.mark.parametrize(
+    ("version", "expected"),
+    (
+        ("7.21.5 (stable)", (7, 21, 5)),
+        ("6.49.21 (long-term)", (6, 49, 21)),
+        ("7.16rc1 (testing)", (7, 16)),
+        ("7.16beta2", (7, 16)),
+        ("7.13", (7, 13)),
+    ),
+)
+def test_parse_version(version, expected):
+    # Testing/RC builds tag the version component (e.g. "7.16rc1"); a plain int() would crash.
+    assert parse_version(version) == expected
+
+
+def test_file_contents_large_file_on_testing_build():
+    # The large-file path calls _version(); on a testing build it must not crash (was ValueError).
+    big = "".join(f"line {i}\n" for i in range(20000))  # > _READ_CHUNK bytes
+    fake = FilteringFake(
+        {"/file/print": [{".id": "*1", "name": "big.rsc", "size": len(big)}]},
+        blobs={"big.rsc": big},
+        version="7.16rc1 (testing)",
+    )
+    assert Config(api=fake)._file_contents("big.rsc") == big
+
+
+def test_file_read_advances_by_bytes_not_str_length():
+    # /file/read offsets are device byte offsets. Under a multibyte encoding a chunk decodes
+    # to fewer chars than its byte length, so advancing by len(str) would re-read overlapping
+    # data. _file_read must advance by the byte count requested instead.
+    class ByteOffsetFake:
+        def __init__(self, size):
+            self.size = size
+            self.offsets = []
+
+        def __call__(self, cmd, **kwargs):
+            assert cmd == "/file/read"
+            self.offsets.append(kwargs["offset"])
+            nbytes = min(kwargs["chunk-size"], self.size - kwargs["offset"])
+            return iter([{"data": "u" * (nbytes // 2)}])  # half as many chars as bytes
+
+    size = _READ_CHUNK * 3 + 100
+    fake = ByteOffsetFake(size)
+    Config(api=fake)._file_read("big.rsc", size)
+    assert fake.offsets == list(range(0, size, _READ_CHUNK))
 
 
 def test_backup_exists():


### PR DESCRIPTION
Two fixes on the large-file read path used by `Config.export()`:

- `_version()` ran `int()` on each dotted version component, so a RouterOS testing build (`7.16rc1`) raised `ValueError`. Parse the leading digits per component instead (`7.16rc1` -> `(7, 16)`).
- `_file_read()` advanced the device byte offset by `len(decoded_str)`. `/file/read` offsets are byte offsets; under a multibyte encoding the decoded string is shorter than the bytes read, so the next read re-fetched overlapping data. Advance by the byte count requested instead.

Both apply to the sync and async paths, with unit tests for version parsing (incl. rc/beta) and byte-correct chunk offsets.
