### PR TITLE
Return an empty id from Path.add when RouterOS omits =ret=

### DIFF
--- a/src/librouteros/api.py
+++ b/src/librouteros/api.py
@@ -137,11 +137,11 @@ class Path:
         )
 
     def add(self, **kwargs: ROSType) -> str:
-        ret: ResponseIter = self(
-            "add",
-            **kwargs,
-        )
-        return str(next(iter(ret))["ret"])
+        rows = tuple(self("add", **kwargs))
+        # Not every RouterOS version returns =ret= for an add (e.g. /file/add on
+        # RouterOS older than ~7.13 returns nothing), so fall back to an empty id
+        # instead of raising StopIteration.
+        return str(rows[0]["ret"]) if rows and "ret" in rows[0] else ""
 
     def update(self, **kwargs: ROSType) -> None:
         tuple(
@@ -272,14 +272,9 @@ class AsyncPath:
         ]
 
     async def add(self, **kwargs: ROSType) -> str:
-        response: Response = [
-            response
-            async for response in self(
-                "add",
-                **kwargs,
-            )
-        ]
-        return str(response[0]["ret"])
+        rows: Response = [row async for row in self("add", **kwargs)]
+        # See sync Path.add: some RouterOS versions omit =ret= on an add.
+        return str(rows[0]["ret"]) if rows and "ret" in rows[0] else ""
 
     async def update(self, **kwargs: ROSType) -> None:
         [

--- a/tests/unit/test_path.py
+++ b/tests/unit/test_path.py
@@ -99,6 +99,21 @@ class Test_Path:
         assert new_id == "*1"
 
     @pytest.mark.asyncio
+    async def test_add_without_ret_returns_empty(self):
+        # Some RouterOS versions return no =ret= for an add (e.g. /file/add on RouterOS
+        # older than ~7.13), so add() must return "" instead of raising StopIteration
+        # (sync) / IndexError (async).
+        self.path.api.return_value = ()
+        assert self.path.add(name="x") == ""
+
+        async def mock_api(*args, **kwargs):
+            for item in ():  # pragma: no cover - empty async response
+                yield item
+
+        self.async_path.api.side_effect = mock_api
+        assert await self.async_path.add(name="x") == ""
+
+    @pytest.mark.asyncio
     async def test_update(self):
         args = {"name": "wan", ".id": "*1"}
         self.path.update(**args)


### PR DESCRIPTION
`Path.add` returned `str(next(iter(ret))["ret"])` (sync) / `str(response[0]["ret"])` (async), which raises `StopIteration` / `IndexError` when an add returns no `=ret=`. RouterOS omits it in some cases -- notably **`/file/add` on RouterOS older than ~7.13 returns an empty response** -- which broke every `add()`-based operation on those versions, including the config engine's `apply()` (upload-then-`/import`), and therefore `commit_config`.

Fall back to an empty id instead of raising. Versions that return `=ret=` are unaffected.

Verified live on RouterOS 7.12.2: `/file/add` returns `[]` there (vs `[{'ret': ...}]` on 7.21.5), so before this change `apply()` / `commit` raised `StopIteration`; after it, a merge commits cleanly. Unit test covers the empty-response case, sync and async.
