### PR TITLE
Parse RouterOS version strings that tag the component

### DIFF
--- a/src/librouteros/config.py
+++ b/src/librouteros/config.py
@@ -50,6 +50,21 @@ _READ_CHUNK = 32768
 _READ_RETRIES = 6
 _READ_RETRY_DELAY = 0.2
 
+
+def parse_version(version: str) -> tuple[int, ...]:
+    """Parse a RouterOS version string such as ``"7.16rc1 (testing)"`` into ``(7, 16)``."""
+    digits = re.compile(r"\d+")
+
+    def gen():
+        for part in version.split("."):
+            match = digits.match(part)
+            if match is None:
+                break
+            yield int(match.group())
+
+    return tuple(gen())
+
+
 # Marks the rollback scheduler as ours so a user job that happens to share the reserved
 # name is not mistaken for it (and never removed by cancel_rollback).
 ROLLBACK_COMMENT = "librouteros rollback dead man switch"
@@ -215,7 +230,7 @@ class Config:
 
     def _version(self) -> tuple[int, ...]:
         version = next(iter(self.api("/system/resource/print")))["version"]
-        return tuple(int(part) for part in str(version).split()[0].split("."))
+        return parse_version(str(version))
 
     def _file_contents(self, name: str) -> str:
         rows = tuple(self.api.path("file").select(_SIZE, _CONTENTS).where(_NAME == name))
@@ -513,7 +528,7 @@ class AsyncConfig:
 
     async def _version(self) -> tuple[int, ...]:
         rows = [row async for row in self.api("/system/resource/print")]
-        return tuple(int(part) for part in str(rows[0]["version"]).split()[0].split("."))
+        return parse_version(str(rows[0]["version"]))
 
     async def _file_contents(self, name: str) -> str:
         rows = [row async for row in self.api.path("file").select(_SIZE, _CONTENTS).where(_NAME == name)]

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -22,6 +22,7 @@ from librouteros.config import (
     export_args,
     export_command,
     import_args,
+    parse_version,
     reset_args,
     ros_quote,
     scheduler_args,
@@ -415,6 +416,32 @@ def test_file_contents_large_file_pre_7_13_raises():
     )
     with pytest.raises(NotImplementedError, match=r"7\.13"):
         Config(api=fake)._file_contents("big.rsc")
+
+
+@pytest.mark.parametrize(
+    ("version", "expected"),
+    (
+        ("7.21.5 (stable)", (7, 21, 5)),
+        ("6.49.21 (long-term)", (6, 49, 21)),
+        ("7.16rc1 (testing)", (7, 16)),
+        ("7.16beta2", (7, 16)),
+        ("7.13", (7, 13)),
+    ),
+)
+def test_parse_version(version, expected):
+    # Testing/RC builds tag the version component (e.g. "7.16rc1"); a plain int() would crash.
+    assert parse_version(version) == expected
+
+
+def test_file_contents_large_file_on_testing_build():
+    # The large-file path calls _version(); on a testing build it must not crash (was ValueError).
+    big = "".join(f"line {i}\n" for i in range(20000))  # > _READ_CHUNK bytes
+    fake = FilteringFake(
+        {"/file/print": [{".id": "*1", "name": "big.rsc", "size": len(big)}]},
+        blobs={"big.rsc": big},
+        version="7.16rc1 (testing)",
+    )
+    assert Config(api=fake)._file_contents("big.rsc") == big
 
 
 def test_backup_exists():


### PR DESCRIPTION
Split out of #387 (first of two), as requested.

Testing and release-candidate builds tag a version component (e.g. `7.16rc1`), which `int()` cannot parse, so `_version()` crashed with a `ValueError` on those builds. Add `parse_version()` to read the leading integer of each component and stop at the first non-numeric one, and use it in both the sync and async `_version()`.