### PR TITLE
Advance the file-read offset by byte count, not string length

### DIFF
--- a/src/librouteros/config.py
+++ b/src/librouteros/config.py
@@ -234,11 +234,11 @@ class Config:
         parts: list[str] = []
         offset = 0
         while offset < size:
-            data = self._read_chunk(name, offset)
-            if not data:
-                break
-            parts.append(data)
-            offset += len(data)
+            parts.append(self._read_chunk(name, offset))
+            # /file/read serves at most _READ_CHUNK bytes per call. Advance by the byte
+            # count requested, not len(str): under a multibyte encoding the two diverge and
+            # advancing by the shorter string length would re-read overlapping data.
+            offset += min(_READ_CHUNK, size - offset)
         return "".join(parts)
 
     def _read_chunk(self, name: str, offset: int) -> str:
@@ -531,11 +531,11 @@ class AsyncConfig:
         parts: list[str] = []
         offset = 0
         while offset < size:
-            data = await self._read_chunk(name, offset)
-            if not data:
-                break
-            parts.append(data)
-            offset += len(data)
+            parts.append(await self._read_chunk(name, offset))
+            # /file/read serves at most _READ_CHUNK bytes per call. Advance by the byte
+            # count requested, not len(str): under a multibyte encoding the two diverge and
+            # advancing by the shorter string length would re-read overlapping data.
+            offset += min(_READ_CHUNK, size - offset)
         return "".join(parts)
 
     async def _read_chunk(self, name: str, offset: int) -> str:

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -10,6 +10,7 @@ import pytest
 
 from librouteros.api import Api, AsyncApi, Path
 from librouteros.config import (
+    _READ_CHUNK,
     EXPORT_FILE,
     IMPORT_FILE,
     ROLLBACK_COMMENT,
@@ -415,6 +416,27 @@ def test_file_contents_large_file_pre_7_13_raises():
     )
     with pytest.raises(NotImplementedError, match=r"7\.13"):
         Config(api=fake)._file_contents("big.rsc")
+
+
+def test_file_read_advances_by_bytes_not_str_length():
+    # /file/read offsets are device byte offsets. Under a multibyte encoding a chunk decodes
+    # to fewer chars than its byte length, so advancing by len(str) would re-read overlapping
+    # data. _file_read must advance by the byte count requested instead.
+    class ByteOffsetFake:
+        def __init__(self, size):
+            self.size = size
+            self.offsets = []
+
+        def __call__(self, cmd, **kwargs):
+            assert cmd == "/file/read"
+            self.offsets.append(kwargs["offset"])
+            nbytes = min(kwargs["chunk-size"], self.size - kwargs["offset"])
+            return iter([{"data": "u" * (nbytes // 2)}])  # half as many chars as bytes
+
+    size = _READ_CHUNK * 3 + 100
+    fake = ByteOffsetFake(size)
+    Config(api=fake)._file_read("big.rsc", size)
+    assert fake.offsets == list(range(0, size, _READ_CHUNK))
 
 
 def test_backup_exists():


### PR DESCRIPTION
Split out of #387 (second of two), as requested.

`/file/read` offsets are device byte offsets, but `_file_read` advanced by `len(str)` of the decoded chunk. Under a multibyte encoding a chunk decodes to fewer characters than its byte length, so the next read would start before the end of the previous one and re-read overlapping data. Advance by the byte count requested (capped at the remaining size) instead, in both the sync and async `_file_read`.